### PR TITLE
Add basic dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: ""
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds a minimal dependabot configuration file to enable weekly dependency update checks.

Configuration:
- version: 2
- package-ecosystem: (to be specified)
- directory: "/"
- schedule: weekly
