### PR TITLE
Fix dependabot.yml package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: ""
+  - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot requires a valid package-ecosystem. 
This PR updates it to "gradle" for Android project dependencies.
