### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,5 +1,8 @@
 name: Android CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/0penPublic/onHit/security/code-scanning/1](https://github.com/0penPublic/onHit/security/code-scanning/1)

In general, the problem is fixed by explicitly specifying a minimal `permissions:` block for the workflow or job so that the `GITHUB_TOKEN` has only the rights required. For this Android CI workflow, the steps only read repository contents and upload artifacts; they do not push commits, modify issues, or interact with pull requests. Therefore, `contents: read` is sufficient, and we can apply it at the root workflow level so it covers all jobs by default.

The best fix without changing behavior is to add a `permissions:` section near the top of `.github/workflows/android.yml`, alongside `name:` and `on:`, setting `contents: read`. This ensures the entire workflow runs with read-only access to repository contents, satisfying the CodeQL rule and enforcing least privilege. No other files or imports are involved; this is a pure YAML configuration change contained in `.github/workflows/android.yml`.

Specifically:
- Edit `.github/workflows/android.yml`.
- Insert a `permissions:` block after the `name: Android CI` line (line 1) and before the `on:` section (line 3).
- Set `contents: read` under `permissions:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
