### PR TITLE
fix: resolve ezxhelper dependency version mismatch & missing ReaderModeParams

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     implementation(libs.androidx.swiperefreshlayout)
     implementation(libs.androidx.documentfile)
     compileOnly(libs.xposed.api)
-    implementation(libs.ezxhelper)
+    implementation(libs.ezxhelper.core)
     implementation(libs.ezxhelper.xposed.api)
+    implementation(libs.ezxhelper.android.utils)
 }

--- a/app/src/main/java/mba/vm/onhit/core/TagTechnology.kt
+++ b/app/src/main/java/mba/vm/onhit/core/TagTechnology.kt
@@ -1,5 +1,6 @@
 package mba.vm.onhit.core
 
+@Suppress("unused")
 enum class TagTechnology(val flag: Int) {
     NFC_A(1),
     NFC_B(2),

--- a/app/src/main/java/mba/vm/onhit/ui/FragmentNdefFilePicker.kt
+++ b/app/src/main/java/mba/vm/onhit/ui/FragmentNdefFilePicker.kt
@@ -23,7 +23,6 @@ import mba.vm.onhit.Constant
 import mba.vm.onhit.R
 import mba.vm.onhit.databinding.FragmentNdefFilePickerBinding
 import mba.vm.onhit.ui.adapter.NdefFileAdapter
-import java.security.SecureRandom
 
 
 class FragmentNdefFilePicker : Fragment() {
@@ -226,15 +225,9 @@ class FragmentNdefFilePicker : Fragment() {
         _binding = null
     }
 
-    fun randomBytes(size: Int = 4): ByteArray { // emm... Just like a Mifare Classic Card... I guess?
-        val bytes = ByteArray(size)
-        SecureRandom().nextBytes(bytes)
-        return bytes
-    }
-
     private fun sendNdefBroadcast(ndef: NdefMessage) {
         val intent = Intent(Constant.BROADCAST_TAG_EMULATOR_REQUEST).apply {
-            putExtra("uid", randomBytes())
+            putExtra("uid", byteArrayOf())
             putExtra("ndef", ndef)
         }
         requireContext().sendBroadcast(intent)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "8.13.2"
 kotlin = "2.3.0"
 xposed-api = "82"
+ezxhelper = "3.0.1"
 material = "1.13.0"
 appcompat = "1.7.1"
 constraintlayout = "2.2.1"
@@ -13,8 +14,9 @@ documentfile = "1.1.0"
 
 [libraries]
 xposed-api = { group = "de.robv.android.xposed", name = "api", version.ref = "xposed-api" }
-ezxhelper = { group = "com.github.kyuubiran", name = "EzXHelper", version = "2.2.1" }
-ezxhelper-xposed-api = { module = "io.github.kyuubiran.ezxhelper:xposed-api-82", version = "3.0.1" }
+ezxhelper-android-utils = { module = "io.github.kyuubiran.ezxhelper:android-utils", version.ref = "ezxhelper" }
+ezxhelper-core = { module = "io.github.kyuubiran.ezxhelper:core", version.ref = "ezxhelper" }
+ezxhelper-xposed-api = { module = "io.github.kyuubiran.ezxhelper:xposed-api-82", version.ref = "ezxhelper" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }


### PR DESCRIPTION
- Resolved ezxhelper dependency version inconsistency.
- Added missing ReaderModeParams to dispatchTagEndpoint(), fixing issues where some apps (e.g. NXP TagInfo) could not receive NFC events.
- Removed the 4-byte card UID (now using a zero-length UID, since it is unnecessary).