### PR TITLE
chore: Remove tools:targetApi in AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,8 +11,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
-        android:supportsRtl="true"
-        tools:targetApi="@targetApi">
+        android:supportsRtl="true">
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"
@@ -80,7 +79,6 @@
         <meta-data
             android:name="xposedscope"
             android:value="com.android.nfc" />
-
     </application>
 
 </manifest>


### PR DESCRIPTION
Reverts 0penPublic/onHit#45

明明可以移除掉的 留着干啥