### PR TITLE
refactor: extract constants, implement real Mifare Classic auth, improve storage UX

### DIFF
--- a/app/src/main/java/mba/vm/onhit/Constant.kt
+++ b/app/src/main/java/mba/vm/onhit/Constant.kt
@@ -18,6 +18,8 @@ class Constant {
         const val MAX_OF_BROADCAST_SIZE = 1048576
         const val GITHUB_URL = "https://github.com/0penPublic/onHit"
 
+        const val REQUEST_SELECT_BACKGROUND = 1002
+        const val REQUEST_CROP_BACKGROUND = 1003
         val PACKAGE_MANAGER_SYSTEM_NFC_FEATURES = setOf(PackageManager.FEATURE_NFC, PACKAGE_MANAGER_FEATURE_NFC_ANY)
     }
 }

--- a/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicalParser.kt
+++ b/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicalParser.kt
@@ -49,10 +49,8 @@ object MifareClassicalParser {
     }
 
     fun blockToSector(blockIndex: Int): Int {
-        return if (blockIndex < 32 * 4) {
-            blockIndex / 4
-        } else {
-            32 + (blockIndex - 32 * 4) / 16
-        }
+        if (blockIndex !in 0..<256) return -1
+        return if (blockIndex < 32 * 4) blockIndex / 4
+        else 32 + (blockIndex - 32 * 4) / 16
     }
 }

--- a/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicalParser.kt
+++ b/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicalParser.kt
@@ -47,4 +47,12 @@ object MifareClassicalParser {
         val atqa = byteArrayOf(block0[6], block0[7])
         return atqa to sak
     }
+
+    fun blockToSector(blockIndex: Int): Int {
+        return if (blockIndex < 32 * 4) {
+            blockIndex / 4
+        } else {
+            32 + (blockIndex - 32 * 4) / 16
+        }
+    }
 }

--- a/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
@@ -13,8 +13,8 @@ abstract class BaseFakeTag {
 
     companion object {
         val TAG_TYPE_MAPPING = mapOf(
-            Pair("ndef", Ndef()),
-            Pair("mfc", MifareClassical())
+            Pair("ndef", Ndef::class.java),
+            Pair("mfc", MifareClassical::class.java)
         )
 
         var lastConnectedTechnology = TagTechnology.Unknown

--- a/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
@@ -26,7 +26,7 @@ abstract class BaseFakeTag {
             uid: ByteArray,
             techList: IntArray,
             techExtras: Array<Bundle>,
-            transceive: (cmd: ByteArray) -> ByteArray,
+            transceive: (cmd: ByteArray) -> Pair<Boolean, ByteArray>,
             ndef: NdefMessage? = null
         ): Any {
             lastHandle = SecureRandom().nextInt()
@@ -44,11 +44,25 @@ abstract class BaseFakeTag {
                     "disconnect" -> false
                     "transceive" -> {
                         val data = args?.firstOrNull { it is ByteArray } as? ByteArray
+                        val raw = args?.firstOrNull { it is Boolean } as? Boolean
                         val returnCode = args?.firstOrNull { it is IntArray } as? IntArray
-                        if (returnCode != null && returnCode.isNotEmpty()) {
-                            returnCode[0] = 0 // Success
+                        if (raw != true) {
+                            if (data != null) {
+                                val result = transceive(data)
+                                if (result.first) {
+                                    returnCode?.set(0, 0)
+                                } else {
+                                    returnCode?.set(0, -4)
+                                }
+                                result.second
+                            } else {
+                                returnCode?.set(0, 0)
+                                byteArrayOf()
+                            }
+                        } else {
+                            returnCode?.set(0, 0)
+                            byteArrayOf()
                         }
-                        if (data != null) transceive(data) else byteArrayOf()
                     }
                     "getConnectedTechnology" -> lastConnectedTechnology.flag
                     "getTechList" -> techList

--- a/app/src/main/java/mba/vm/onhit/core/tag/MifareClassical.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/MifareClassical.kt
@@ -5,12 +5,14 @@ import mba.vm.onhit.core.TagTechnology
 import mba.vm.onhit.core.mfc.MifareClassicSector
 import mba.vm.onhit.core.mfc.MifareClassicalParser
 
+// WIP
 class MifareClassical : BaseFakeTag() {
     override val name: String = this.javaClass.name
     var uid: ByteArray = byteArrayOf()
     var sectors: Array<MifareClassicSector> = arrayOf()
     var atqa: ByteArray = byteArrayOf(0x00, 0x04)
     var sak: Short = 0x08
+    var currentUnlockSectorIndex: Int = -1
 
     override fun init(uid: ByteArray, bytes: ByteArray): BaseFakeTag {
         this.uid = uid
@@ -29,46 +31,65 @@ class MifareClassical : BaseFakeTag() {
             val size = sector.dataBlocks.size + 1
             if (targetBlock < currentTotal + size) {
                 val rel = targetBlock - currentTotal
-                return if (rel < sector.dataBlocks.size) sector.dataBlocks[rel].data else sector.trailerBlock
+                if (rel < sector.dataBlocks.size) {
+                    return sector.dataBlocks[rel].data
+                } else {
+                    val rawTrailer = sector.trailerBlock
+                    if (rawTrailer.size < 16) return rawTrailer
+                    val maskedTrailer = ByteArray(16)
+                    System.arraycopy(rawTrailer, 6, maskedTrailer, 6, 4)
+                    System.arraycopy(rawTrailer, 10, maskedTrailer, 10, 6)
+                    return maskedTrailer
+                }
             }
             currentTotal += size
         }
         return null
     }
 
-    fun authentication(cmd: ByteArray): ByteArray? {
-        fun auth(sectorIndex: Int, isKeyB: Boolean, key: ByteArray): ByteArray? {
-            val sector = sectors.getOrNull(sectorIndex) ?: return null
+    fun authentication(cmd: ByteArray): Pair<Boolean, ByteArray> {
+        currentUnlockSectorIndex = -1
+        fun auth(sectorIndex: Int, isKeyB: Boolean, key: ByteArray): Pair<Boolean, ByteArray> {
+            val sector = sectors.getOrNull(sectorIndex) ?: return Pair(false, byteArrayOf())
             val targetKey = if (isKeyB) {
                 sector.trailerBlock.sliceArray(10..15)
             } else {
                 sector.trailerBlock.sliceArray(0..5)
             }
             return if (key.contentEquals(targetKey)) {
-                byteArrayOf(0x00)
+                currentUnlockSectorIndex = sectorIndex
+                Pair(true, byteArrayOf(0x00))
             } else {
-                null
+                Pair(false, byteArrayOf())
             }
         }
-        if (cmd.size < 8) return null
+        if (cmd.size < 12) return Pair(false, byteArrayOf())
         val targetBlock = cmd[1].toInt() and 0xFF
         val sectorIndex = MifareClassicalParser.blockToSector(targetBlock)
-        val providedKey = cmd.sliceArray(2..7)
-        return auth(sectorIndex, cmd[0].toInt() == 0x60, providedKey)
+        val providedKey = cmd.sliceArray(6..11)
+        return auth(sectorIndex, (cmd[0].toInt() and 0xFF) == 0x61, providedKey)
     }
 
-    fun transceive(req: ByteArray): ByteArray {
-        if (req.isEmpty()) return byteArrayOf(0x00)
+    fun transceive(req: ByteArray): Pair<Boolean, ByteArray> {
+        if (req.isEmpty()) return Pair(false, byteArrayOf())
         val firstByte = req[0].toInt() and 0xFF
         when (firstByte) {
-            0x60, 0x61 -> authentication(req)
-            0x30 -> { // Read
-                if (req.size < 2) return byteArrayOf(0x00)
+            0x60, 0x61 -> return authentication(req)
+            0x30 -> {
+                if (req.size < 2) return Pair(false, byteArrayOf())
                 val targetBlock = req[1].toInt() and 0xFF
-                return getBlockData(targetBlock) ?: ByteArray(16)
+                if (currentUnlockSectorIndex != MifareClassicalParser.blockToSector(targetBlock)) {
+                    return Pair(false, byteArrayOf())
+                }
+                val blockData = getBlockData(targetBlock)
+                return if (blockData != null) {
+                    Pair(true, blockData)
+                } else {
+                    Pair(false, byteArrayOf())
+                }
             }
         }
-        return byteArrayOf(0x00)
+        return Pair(true, byteArrayOf())
     }
 
     override fun makeEndpoint(

--- a/app/src/main/java/mba/vm/onhit/core/tag/MifareClassical.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/MifareClassical.kt
@@ -36,11 +36,32 @@ class MifareClassical : BaseFakeTag() {
         return null
     }
 
+    fun authentication(cmd: ByteArray): ByteArray? {
+        fun auth(sectorIndex: Int, isKeyB: Boolean, key: ByteArray): ByteArray? {
+            val sector = sectors.getOrNull(sectorIndex) ?: return null
+            val targetKey = if (isKeyB) {
+                sector.trailerBlock.sliceArray(10..15)
+            } else {
+                sector.trailerBlock.sliceArray(0..5)
+            }
+            return if (key.contentEquals(targetKey)) {
+                byteArrayOf(0x00)
+            } else {
+                null
+            }
+        }
+        if (cmd.size < 8) return null
+        val targetBlock = cmd[1].toInt() and 0xFF
+        val sectorIndex = MifareClassicalParser.blockToSector(targetBlock)
+        val providedKey = cmd.sliceArray(2..7)
+        return auth(sectorIndex, cmd[0].toInt() == 0x60, providedKey)
+    }
+
     fun transceive(req: ByteArray): ByteArray {
         if (req.isEmpty()) return byteArrayOf(0x00)
         val firstByte = req[0].toInt() and 0xFF
         when (firstByte) {
-            0x60, 0x61 -> return byteArrayOf(0x00)
+            0x60, 0x61 -> authentication(req)
             0x30 -> { // Read
                 if (req.size < 2) return byteArrayOf(0x00)
                 val targetBlock = req[1].toInt() and 0xFF

--- a/app/src/main/java/mba/vm/onhit/core/tag/Ndef.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/Ndef.kt
@@ -29,7 +29,7 @@ class Ndef : BaseFakeTag() {
             putInt("ndefcardstate", 1)
             putInt("ndeftype", 4)
         }),
-        { byteArrayOf() },
+        { Pair(true, byteArrayOf()) },
         ndefMessage
     )
 }

--- a/app/src/main/java/mba/vm/onhit/hook/boardcast/NfcServiceHookBroadcastReceiver.kt
+++ b/app/src/main/java/mba/vm/onhit/hook/boardcast/NfcServiceHookBroadcastReceiver.kt
@@ -18,9 +18,9 @@ class NfcServiceHookBroadcastReceiver : BroadcastReceiver() {
                 val tagType = intent.getStringExtra("tagType") ?: "ndef"
                 try {
                     if (uid != null && data != null) {
-                        val tag = TAG_TYPE_MAPPING[tagType]?.init(uid, data)
-                        tag?.let {
-                            dispatchFakeTag(it)
+                        TAG_TYPE_MAPPING[tagType]?.let { clazz ->
+                            val tag = clazz.getDeclaredConstructor().newInstance().init(uid, data)
+                            dispatchFakeTag(tag)
                         }
                     }
                 } catch (e: Exception) {

--- a/app/src/main/java/mba/vm/onhit/ui/MainActivity.kt
+++ b/app/src/main/java/mba/vm/onhit/ui/MainActivity.kt
@@ -38,6 +38,10 @@ import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executors
 import kotlin.system.exitProcess
+import androidx.core.view.isVisible
+import androidx.core.view.isGone
+import mba.vm.onhit.Constant.Companion.REQUEST_CROP_BACKGROUND
+import mba.vm.onhit.Constant.Companion.REQUEST_SELECT_BACKGROUND
 
 class MainActivity : Activity() {
 
@@ -54,10 +58,6 @@ class MainActivity : Activity() {
     private var isRefreshing = false
 
     private var pendingImportUri: Uri? = null
-
-    private val REQUEST_SELECT_BACKGROUND = 1002
-
-    private val REQUEST_CROP_BACKGROUND = 1003
     private var pendingCroppedBackgroundUri: Uri? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -81,7 +81,10 @@ class MainActivity : Activity() {
         binding.rvFiles.adapter = adapter
 
         setupListeners()
-        if (!restoreLastDirectory()) requestSelectDirectory()
+        if (!restoreLastDirectory()) {
+            Toast.makeText(this, R.string.toast_no_valid_storage, Toast.LENGTH_LONG).show()
+            requestSelectDirectory()
+        }
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -173,7 +176,7 @@ class MainActivity : Activity() {
     }
 
     private fun handleBackNavigation(): Boolean {
-        if (binding.etSearch.visibility == View.VISIBLE) {
+        if (binding.etSearch.isVisible) {
             hideSearch()
             return true
         }
@@ -215,7 +218,7 @@ class MainActivity : Activity() {
         }
 
         binding.btnSearch.setOnClickListener {
-            if (binding.etSearch.visibility == View.GONE) {
+            if (binding.etSearch.isGone) {
                 showSearch()
             } else {
                 hideSearch()
@@ -696,38 +699,42 @@ class MainActivity : Activity() {
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == 1001 && resultCode == RESULT_OK) {
-            data?.data?.let { uri ->
-                contentResolver.takePersistableUriPermission(
-                    uri,
-                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                )
-                ConfigManager.setRootUri(this, uri)
-                val df = DocumentFile.fromTreeUri(this, uri)
-                if (df != null && df.exists() && df.canRead()) {
-                    rootDir = df
-                    navigateTo(df)
-                } else {
-                    Toast.makeText(this, R.string.toast_storage_unavailable, Toast.LENGTH_SHORT).show()
-                }
-            }
-        } else if (requestCode == REQUEST_SELECT_BACKGROUND && resultCode == RESULT_OK) {
-            data?.data?.let { uri ->
-                try {
+        when (requestCode) {
+            1001 if resultCode == RESULT_OK -> {
+                data?.data?.let { uri ->
                     contentResolver.takePersistableUriPermission(
                         uri,
-                        Intent.FLAG_GRANT_READ_URI_PERMISSION
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                     )
-                } catch (_: Exception) {
+                    ConfigManager.setRootUri(this, uri)
+                    val df = DocumentFile.fromTreeUri(this, uri)
+                    if (df != null && df.exists() && df.canRead()) {
+                        rootDir = df
+                        navigateTo(df)
+                    } else {
+                        Toast.makeText(this, R.string.toast_storage_unavailable, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+            REQUEST_SELECT_BACKGROUND if resultCode == RESULT_OK -> {
+                data?.data?.let { uri ->
+                    try {
+                        contentResolver.takePersistableUriPermission(
+                            uri,
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION
+                        )
+                    } catch (_: Exception) {
+                    }
+
+                    startCropBackground(uri)
                 }
 
-                startCropBackground(uri)
             }
-
-        } else if (requestCode == REQUEST_CROP_BACKGROUND && resultCode == RESULT_OK) {
-            pendingCroppedBackgroundUri?.let { uri ->
-                ConfigManager.setBackgroundUri(this, uri)
-                applyCustomBackground()
+            REQUEST_CROP_BACKGROUND if resultCode == RESULT_OK -> {
+                pendingCroppedBackgroundUri?.let { uri ->
+                    ConfigManager.setBackgroundUri(this, uri)
+                    applyCustomBackground()
+                }
             }
         }
     }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -26,6 +26,7 @@
     <string name="toast_send_broadcast_failed">广播发送失败，原因: %s</string>
     <string name="toast_nfc_not_supported">NFC 不可用。某些功能可能会受到限制。</string>
 
+    <string name="toast_no_valid_storage">当前未配置有效的存储目录，请在文件管理器中选择或创建一个文件夹作为存储目录。</string>
     <string name="import_ndef">从标签导入 NDEF</string>
     <string name="read_nfc_tag">读取 NFC 标签</string>
     <string name="write_nfc_tag">写入 NFC 标签</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -26,7 +26,7 @@
     <string name="toast_send_broadcast_failed">广播发送失败，原因: %s</string>
     <string name="toast_nfc_not_supported">NFC 不可用。某些功能可能会受到限制。</string>
 
-    <string name="toast_no_valid_storage">当前未配置有效的存储目录，请在文件管理器中选择或创建一个文件夹作为存储目录。</string>
+    <string name="toast_no_valid_storage">未配置有效存储目录，请在文件管理器中选择或创建一个文件夹作为存储目录。</string>
     <string name="import_ndef">从标签导入 NDEF</string>
     <string name="read_nfc_tag">读取 NFC 标签</string>
     <string name="write_nfc_tag">写入 NFC 标签</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="dialog_title_path">Path</string>
     <string name="toast_send_broadcast_failed">Failed to send broadcast, reason: %s</string>
     <string name="toast_nfc_not_supported">NFC is not available. Some features may be limited.</string>
+    <string name="toast_no_valid_storage">No valid storage directory is configured. Please select or create a folder in the file manager and set it as the storage directory.</string>
 
     <string name="import_ndef">Import NDEF from Tag</string>
     <string name="read_nfc_tag">Read NFC Tag</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
     <string name="dialog_title_path">Path</string>
     <string name="toast_send_broadcast_failed">Failed to send broadcast, reason: %s</string>
     <string name="toast_nfc_not_supported">NFC is not available. Some features may be limited.</string>
-    <string name="toast_no_valid_storage">No valid storage directory is configured. Please select or create a folder in the file manager and set it as the storage directory.</string>
+    <string name="toast_no_valid_storage">Storage directory is not set or invalid. Please select or create a folder.</string>
 
     <string name="import_ndef">Import NDEF from Tag</string>
     <string name="read_nfc_tag">Read NFC Tag</string>


### PR DESCRIPTION
- Move background picker request codes to Constant
- Show toast when no valid storage directory configured
- Replace == View.VISIBLE/GONE with isVisible/isGone
- Refactor onActivityResult to when expression
- Switch TAG_TYPE_MAPPING to KClass references with reflection init
- Implement actual Mifare Classic key verification instead of always returning success
- Add blockToSector utility to MifareClassicalParser
- Add toast_no_valid_storage string (zh & en)