### PR TITLE
fix(core/tag): fix type mismatch in BaseFakeTag.getHandle

### DIFF
--- a/.github/workflows/manual-build-and-publish.yml
+++ b/.github/workflows/manual-build-and-publish.yml
@@ -135,8 +135,12 @@ jobs:
           
       - name: Attest Build Provenance
         uses: actions/attest@v4
+        id: attest
         with:
           subject-path: 'release_assets/*.apk'
+
+      - name: Move attestation to release assets
+        run: cp ${{ steps.attest.outputs.bundle-path }} release_assets/attestation.jsonl
 
       - name: Create Release
         uses: softprops/action-gh-release@v3
@@ -176,6 +180,7 @@ jobs:
           echo "xmr_tag=$XMR_TAG" >> $GITHUB_OUTPUT
           echo "version_name=$VN" >> $GITHUB_OUTPUT
           rm -rf release_assets/mapping.zip
+          rm -rf release_assets/checksums_sha256.txt
 
       - name: Fetch Release
         env:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         minSdk = 26
         targetSdk = 37
         versionCode = getGitCommitCount()
-        versionName = "1.1.4-$currentGitHash"
+        versionName = "1.1.3-$currentGitHash"
     }
 
     val keystoreFile = rootProject.file(project.findProperty("KEYSTORE_FILE") ?: "key.jks")

--- a/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
@@ -69,7 +69,7 @@ abstract class BaseFakeTag {
                     "getTechList" -> techList
                     "getTechExtras" -> techExtras
                     "isPresent" -> true
-                    "getHandle" -> lastHandle
+                    "getHandle" -> lastHandle.toInt()
                     "getTechHandles" -> IntArray(techList.size) { lastHandle.toInt() }
                     else -> {
                         when (method.returnType) {


### PR DESCRIPTION
- Convert getHandle return value from String/Long to Int (lastHandle.toInt())
- Ensure consistency with getTechHandles IntArray usage

ci:
- Add `id: attest` to Attest Build Provenance step
- Copy attestation bundle to release_assets/attestation.jsonl
- Remove checksums_sha256.txt during release asset cleanup