### PR TITLE
fix(nfc): fix ClassLoader isolation issue and refactor tag/hook names

### DIFF
--- a/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
@@ -7,7 +7,8 @@ import java.lang.reflect.Proxy
 import java.security.SecureRandom
 
 abstract class BaseFakeTag {
-    abstract val name: String
+    open val name: String
+        get() = this::class.java.simpleName
     abstract fun init(uid: ByteArray, bytes: ByteArray): BaseFakeTag
     abstract fun makeEndpoint(nfcClassloader: ClassLoader, tagEndpointInterface: Class<*>): Any
 

--- a/app/src/main/java/mba/vm/onhit/core/tag/MifareClassic.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/MifareClassic.kt
@@ -7,7 +7,6 @@ import mba.vm.onhit.core.mfc.MifareClassicParser
 
 // WIP
 class MifareClassic : BaseFakeTag() {
-    override val name: String = this.javaClass.name
     var uid: ByteArray = byteArrayOf()
     var sectors: Array<MifareClassicSector> = arrayOf()
     var atqa: ByteArray = byteArrayOf(0x00, 0x04)

--- a/app/src/main/java/mba/vm/onhit/core/tag/Ndef.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/Ndef.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import mba.vm.onhit.core.TagTechnology
 
 class Ndef : BaseFakeTag() {
-    override val name: String = this.javaClass.name
     lateinit var ndefMessage: NdefMessage
     lateinit var uid: ByteArray
 

--- a/app/src/main/java/mba/vm/onhit/hook/BaseHook.kt
+++ b/app/src/main/java/mba/vm/onhit/hook/BaseHook.kt
@@ -5,7 +5,8 @@ import mba.vm.onhit.BuildConfig
 
 abstract class BaseHook {
 
-    abstract val name: String
+    open val name: String
+        get() = this::class.java.simpleName
     abstract fun init(classLoader: ClassLoader, packageName: String)
 
     fun log(text: String) = if (BuildConfig.DEBUG) Logger.i("[ onHit ] [ $name ] $text") else Unit

--- a/app/src/main/java/mba/vm/onhit/hook/NfcDispatchManagerHook.kt
+++ b/app/src/main/java/mba/vm/onhit/hook/NfcDispatchManagerHook.kt
@@ -12,8 +12,6 @@ import mba.vm.onhit.BuildConfig
  *   when this app is in the foreground.
  */
 object NfcDispatchManagerHook : BaseHook() {
-    override val name: String = this.javaClass.simpleName
-
     override fun init(classLoader: ClassLoader, packageName: String) {
         val clazz = try {
             Class.forName("com.oplus.nfc.dispatch.NfcDispatchManager", false, classLoader)

--- a/app/src/main/java/mba/vm/onhit/hook/NfcServiceHook.kt
+++ b/app/src/main/java/mba/vm/onhit/hook/NfcServiceHook.kt
@@ -23,9 +23,6 @@ object NfcServiceHook : BaseHook() {
     private lateinit var dispatchTagEndpoint: Method
     private lateinit var tagEndpointInterface: Class<*>
 
-    override val name: String = this.javaClass.simpleName
-
-
     fun findAvailableClass(classLoader: ClassLoader, vararg classNames: String): Class<*>? {
         classNames.forEach { name ->
             runCatching {
@@ -83,7 +80,8 @@ object NfcServiceHook : BaseHook() {
     fun dispatchFakeTag(
         fakeTag: BaseFakeTag
     ) {
-        val tag = fakeTag.makeEndpoint(nfcClassLoader, tagEndpointInterface)
+        val targetClassLoader = tagEndpointInterface.classLoader ?: nfcClassLoader
+        val tag = fakeTag.makeEndpoint(targetClassLoader, tagEndpointInterface)
         nfcServiceHandler.post {
             dispatchTagEndpoint.invoke(
                 nfcServiceHandler,

--- a/app/src/main/java/mba/vm/onhit/hook/PackageManagerHook.kt
+++ b/app/src/main/java/mba/vm/onhit/hook/PackageManagerHook.kt
@@ -5,7 +5,6 @@ import io.github.kyuubiran.ezxhelper.xposed.dsl.HookFactory.`-Static`.createHook
 import mba.vm.onhit.Constant.Companion.PACKAGE_MANAGER_SYSTEM_NFC_FEATURES
 
 object PackageManagerHook : BaseHook() {
-    override val name: String = this.javaClass.simpleName
     override fun init(classLoader: ClassLoader, packageName: String) {
         MethodFinder.fromClass(
             "android.app.ApplicationPackageManager",


### PR DESCRIPTION
- Fix `IllegalArgumentException` caused by ClassLoader visibility issues when dispatching fake tags on MIUI/HyperOS devices. Fallback to `tagEndpointInterface.classLoader` if available.
- Refactor `BaseHook` and `BaseFakeTag` to automatically retrieve the simple class name via reflection, removing redundant boilerplate code from subclasses.