### PR TITLE
refactor(xposed): extract xposed scope definition to resource array

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,7 +82,7 @@
             android:value="82" />
         <meta-data
             android:name="xposedscope"
-            android:value="com.android.nfc,com.samsung.android.nfc" />
+            android:resource="@array/xposed_scope" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="xposed_scope" translatable="false">
+        <item>com.android.nfc</item>
+        <item>com.samsung.android.nfc</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
- Remove hardcoded package list for `xposedscope` from `AndroidManifest.xml`.
- Add `xposed_scope` string array in `arrays.xml` and mark it as non-translatable.
- Update manifest to reference the newly created resource array.