### PR TITLE
refactor: optimize code style and migrate to Android KTX

### DIFF
--- a/app/src/main/java/mba/vm/onhit/core/ConfigManager.kt
+++ b/app/src/main/java/mba/vm/onhit/core/ConfigManager.kt
@@ -11,16 +11,18 @@ import mba.vm.onhit.Constant.Companion.SHARED_PREFERENCES_NAME
 import mba.vm.onhit.utils.HexUtils
 import java.security.SecureRandom
 import mba.vm.onhit.Constant.Companion.PREF_BACKGROUND_URI
+import androidx.core.content.edit
+import androidx.core.net.toUri
 
 object ConfigManager {
     fun getRootUri(context: Context): Uri? {
         val prefs = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
-        return prefs.getString(SHARED_PREFERENCES_CHOSEN_FOLDER, null).let { if (it.isNullOrEmpty()) null else Uri.parse(it) }
+        return prefs.getString(SHARED_PREFERENCES_CHOSEN_FOLDER, null).let { if (it.isNullOrEmpty()) null else it.toUri() }
     }
 
     fun setRootUri(context: Context, uri: Uri) {
         context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
-            .edit().putString(SHARED_PREFERENCES_CHOSEN_FOLDER, uri.toString()).apply()
+            .edit { putString(SHARED_PREFERENCES_CHOSEN_FOLDER, uri.toString()) }
     }
 
     fun isFixedUid(context: Context): Boolean {
@@ -30,7 +32,7 @@ object ConfigManager {
 
     fun setFixedUid(context: Context, fixed: Boolean) {
         context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
-            .edit().putBoolean(PREF_FIXED_UID, fixed).apply()
+            .edit { putBoolean(PREF_FIXED_UID, fixed) }
     }
 
     fun getFixedUidValue(context: Context): String {
@@ -40,7 +42,7 @@ object ConfigManager {
 
     fun setFixedUidValue(context: Context, value: String) {
         context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
-            .edit().putString(PREF_FIXED_UID_VALUE, value).apply()
+            .edit { putString(PREF_FIXED_UID_VALUE, value) }
     }
 
     fun getRandomUidLen(context: Context): String {
@@ -51,22 +53,22 @@ object ConfigManager {
 
     fun setRandomUidLen(context: Context, len: String) {
         context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
-            .edit().putString(PREF_RANDOM_UID_LEN, len).apply()
+            .edit { putString(PREF_RANDOM_UID_LEN, len) }
     }
 
 
     fun getBackgroundUri(context: Context): Uri? {
         val value = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
             .getString(PREF_BACKGROUND_URI, null)
-        return if (value.isNullOrEmpty()) null else Uri.parse(value)
+        return if (value.isNullOrEmpty()) null else value.toUri()
     }
 
     fun setBackgroundUri(context: Context, uri: Uri?) {
         context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
-            .edit().apply {
+            .edit {
                 if (uri == null) remove(PREF_BACKGROUND_URI)
                 else putString(PREF_BACKGROUND_URI, uri.toString())
-            }.apply()
+            }
     }
 
     fun getUid(context: Context): ByteArray {

--- a/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
@@ -48,20 +48,25 @@ abstract class BaseFakeTag {
                         val data = args?.firstOrNull { it is ByteArray } as? ByteArray
                         val raw = args?.firstOrNull { it is Boolean } as? Boolean
                         val returnCode = args?.firstOrNull { it is IntArray } as? IntArray
-                        if (raw != true) {
-                            if (data != null) {
-                                val result = transceive(data)
-                                if (result.first) {
+                        raw?.let {
+                            if (!it) {
+                                data?.let {
+                                    val result = transceive(data)
+                                    if (result.first) {
+                                        returnCode?.set(0, 0)
+                                    } else {
+                                        returnCode?.set(0, -4)
+                                    }
+                                    result.second
+                                } ?: run {
                                     returnCode?.set(0, 0)
-                                } else {
-                                    returnCode?.set(0, -4)
+                                    byteArrayOf()
                                 }
-                                result.second
                             } else {
                                 returnCode?.set(0, 0)
                                 byteArrayOf()
                             }
-                        } else {
+                        } ?: run {
                             returnCode?.set(0, 0)
                             byteArrayOf()
                         }

--- a/app/src/main/java/mba/vm/onhit/core/tag/MifareClassic.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/MifareClassic.kt
@@ -94,8 +94,7 @@ class MifareClassic : BaseFakeTag() {
     override fun makeEndpoint(
         nfcClassloader: ClassLoader,
         tagEndpointInterface: Class<*>
-    ): Any {
-        return createTagEndpoint(
+    ): Any = createTagEndpoint(
             nfcClassloader,
             tagEndpointInterface,
             uid,
@@ -112,5 +111,4 @@ class MifareClassic : BaseFakeTag() {
             ),
             ::transceive
         )
-    }
 }

--- a/app/src/main/java/mba/vm/onhit/ui/handler/NfcHandler.kt
+++ b/app/src/main/java/mba/vm/onhit/ui/handler/NfcHandler.kt
@@ -101,10 +101,10 @@ class NfcHandler(private val activity: Activity) {
                 Toast.makeText(activity, R.string.toast_write_success, Toast.LENGTH_SHORT).show()
                 closeAction()
             } else {
-                val formatable = NdefFormatable.get(tag)
-                if (formatable != null) {
-                    formatable.connect()
-                    formatable.format(message)
+                val formatAble = NdefFormatable.get(tag)
+                if (formatAble != null) {
+                    formatAble.connect()
+                    formatAble.format(message)
                     Toast.makeText(activity, R.string.toast_write_success, Toast.LENGTH_SHORT).show()
                     closeAction()
                 } else {


### PR DESCRIPTION
- Use `?.let` and `?: run` scope functions in BaseFakeTag for better null-safety and clarity.
- Utilize `androidx.core.content.edit` KTX extension for SharedPreferences modifications in ConfigManager.
- Convert Uri.parse() to String.toUri() extension function.
- Simplify makeEndpoint to an expression body in MifareClassic.
- Fix typo formatable -> formatAble in NfcHandler.