### PR TITLE
feat(nfc): support Mifare Classic NDEF parsing and improve fake tag emulation

### DIFF
--- a/app/src/main/java/mba/vm/onhit/Constant.kt
+++ b/app/src/main/java/mba/vm/onhit/Constant.kt
@@ -22,8 +22,5 @@ class Constant {
         const val REQUEST_SELECT_BACKGROUND = 1002
         const val REQUEST_CROP_BACKGROUND = 1003
         val PACKAGE_MANAGER_SYSTEM_NFC_FEATURES = setOf(PackageManager.FEATURE_NFC, PACKAGE_MANAGER_FEATURE_NFC_ANY)
-
-        val KEY_MAD_NFC_FORUM = byteArrayOf(0xA0.toByte(), 0xA1.toByte(), 0xA2.toByte(), 0xA3.toByte(), 0xA4.toByte(), 0xA5.toByte())
-        val KEY_NDEF_APPLICATION = byteArrayOf(0xD3.toByte(), 0xF7.toByte(), 0xD3.toByte(), 0xF7.toByte(), 0xD3.toByte(), 0xF7.toByte())
     }
 }

--- a/app/src/main/java/mba/vm/onhit/Constant.kt
+++ b/app/src/main/java/mba/vm/onhit/Constant.kt
@@ -22,5 +22,8 @@ class Constant {
         const val REQUEST_SELECT_BACKGROUND = 1002
         const val REQUEST_CROP_BACKGROUND = 1003
         val PACKAGE_MANAGER_SYSTEM_NFC_FEATURES = setOf(PackageManager.FEATURE_NFC, PACKAGE_MANAGER_FEATURE_NFC_ANY)
+
+        val KEY_MAD_NFC_FORUM = byteArrayOf(0xA0.toByte(), 0xA1.toByte(), 0xA2.toByte(), 0xA3.toByte(), 0xA4.toByte(), 0xA5.toByte())
+        val KEY_NDEF_APPLICATION = byteArrayOf(0xD3.toByte(), 0xF7.toByte(), 0xD3.toByte(), 0xF7.toByte(), 0xD3.toByte(), 0xF7.toByte())
     }
 }

--- a/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicParser.kt
+++ b/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicParser.kt
@@ -1,8 +1,66 @@
 package mba.vm.onhit.core.mfc
 
+import android.nfc.NdefMessage
+import android.util.Log
+import mba.vm.onhit.Constant.Companion.KEY_MAD_NFC_FORUM
+import mba.vm.onhit.Constant.Companion.KEY_NDEF_APPLICATION
+import mba.vm.onhit.utils.HexUtils.encodeHex
+import java.io.ByteArrayOutputStream
+
 object MifareClassicParser {
     const val MIFARE_CLASSICAL_BLOCK_SIZE = 16
 
+    fun checkNdef(sectors: Array<MifareClassicSector>): NdefMessage? {
+        if (sectors.isEmpty()) return null
+        val allDataBytes = ByteArrayOutputStream()
+        for ((sectorIndex, sector) in sectors.withIndex()) {
+            val expectedKey = if (sectorIndex == 0) KEY_MAD_NFC_FORUM else KEY_NDEF_APPLICATION
+            if (!sector.trailerBlock.keyA.contentEquals(expectedKey)) return null
+            if (sectorIndex == 0) continue
+            for (block in sector.dataBlocks) {
+                allDataBytes.write(block.data)
+            }
+        }
+        return parseNdefFromRawBytes(allDataBytes.toByteArray())
+    }
+
+    private fun parseNdefFromRawBytes(rawBytes: ByteArray): NdefMessage? {
+        return runCatching {
+            var index = 0
+            var ndefBytes: ByteArray? = null
+            while (index < rawBytes.size) {
+                val tag = rawBytes[index].toInt() and 0xFF
+                when (tag) {
+                    0x00 -> index++
+                    0xFE -> break
+                    0x03 -> {
+                        index++
+                        var length = rawBytes[index].toInt() and 0xFF
+                        index++
+                        if (length == 0xFF) {
+                            val lenH = rawBytes[index].toInt() and 0xFF
+                            val lenL = rawBytes[index + 1].toInt() and 0xFF
+                            length = (lenH shl 8) or lenL
+                            index += 2
+                        }
+                        if (index + length <= rawBytes.size) ndefBytes = rawBytes.copyOfRange(index, index + length)
+                        break
+                    }
+                    else -> {
+                        index++
+                        val length = rawBytes[index].toInt() and 0xFF
+                        index += 1 + length
+                    }
+                }
+            }
+            ndefBytes?.let {
+                Log.i(this::class.simpleName, "NDEF Data: ${encodeHex(it)}")
+                NdefMessage(it)
+            }
+        }.onFailure { e ->
+            Log.e(this::class.simpleName, "Parsing NDEF failed", e)
+        }.getOrNull()
+    }
     fun parse(fileBytes: ByteArray): Array<MifareClassicSector> {
         val sectors = mutableListOf<MifareClassicSector>()
         var byteOffset = 0
@@ -31,7 +89,7 @@ object MifareClassicParser {
             sectors.add(
                 MifareClassicSector(
                     dataBlocks,
-                    trailerBlock
+                    MifareClassicSector.MifareTrailerBlock.fromByteArray(trailerBlock)
                 )
             )
             byteOffset += sectorSizeInBytes
@@ -53,4 +111,17 @@ object MifareClassicParser {
         return if (blockIndex < 32 * 4) blockIndex / 4
         else 32 + (blockIndex - 32 * 4) / 16
     }
+
+    val Array<MifareClassicSector>.maxNdefMessageSize: Int
+        get() {
+            if (this.size < 2) return 0
+            val ndefSectors = this.drop(1)
+            val totalNdefPhysicalBytes = ndefSectors.sumOf { sector ->
+                sector.dataBlocks.size * MIFARE_CLASSICAL_BLOCK_SIZE
+            }
+            if (totalNdefPhysicalBytes == 0) return 0
+            val tlvHeaderExpense = 4
+            val maxPayload = totalNdefPhysicalBytes - tlvHeaderExpense
+            return if (maxPayload > 0) maxPayload else 0
+        }
 }

--- a/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicParser.kt
+++ b/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicParser.kt
@@ -2,13 +2,13 @@ package mba.vm.onhit.core.mfc
 
 import android.nfc.NdefMessage
 import android.util.Log
-import mba.vm.onhit.Constant.Companion.KEY_MAD_NFC_FORUM
-import mba.vm.onhit.Constant.Companion.KEY_NDEF_APPLICATION
 import mba.vm.onhit.utils.HexUtils.encodeHex
 import java.io.ByteArrayOutputStream
 
 object MifareClassicParser {
     const val MIFARE_CLASSICAL_BLOCK_SIZE = 16
+    val KEY_MAD_NFC_FORUM = byteArrayOf(0xA0.toByte(), 0xA1.toByte(), 0xA2.toByte(), 0xA3.toByte(), 0xA4.toByte(), 0xA5.toByte())
+    val KEY_NDEF_APPLICATION = byteArrayOf(0xD3.toByte(), 0xF7.toByte(), 0xD3.toByte(), 0xF7.toByte(), 0xD3.toByte(), 0xF7.toByte())
 
     fun checkNdef(sectors: Array<MifareClassicSector>): NdefMessage? {
         if (sectors.isEmpty()) return null

--- a/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicSector.kt
+++ b/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicSector.kt
@@ -2,11 +2,72 @@ package mba.vm.onhit.core.mfc
 
 import mba.vm.onhit.core.mfc.MifareClassicParser.MIFARE_CLASSICAL_BLOCK_SIZE
 
-
 data class MifareClassicSector(
     var dataBlocks: Array<MifareBlock>,
-    var trailerBlock: ByteArray
+    var trailerBlock: MifareTrailerBlock
 ) {
+
+    data class MifareTrailerBlock(
+        val keyA: ByteArray = ByteArray(6) { 0xFF.toByte() },
+        val accessBits: ByteArray = byteArrayOf(0xFF.toByte(), 0x07.toByte(), 0x80.toByte()),
+        val userData: Byte = 0x69.toByte(),
+        val keyB: ByteArray = ByteArray(6) { 0xFF.toByte() }
+    ) {
+        init {
+            require(keyA.size == 6) { "Key A must be 6 bytes" }
+            require(accessBits.size == 3) { "Access Bits must be 3 bytes" }
+            require(keyB.size == 6) { "Key B must be 6 bytes" }
+        }
+
+        fun toByteArray(): ByteArray {
+            val result = ByteArray(16)
+            System.arraycopy(keyA, 0, result, 0, 6)
+            System.arraycopy(accessBits, 0, result, 6, 3)
+            result[9] = userData
+            System.arraycopy(keyB, 0, result, 10, 6)
+            return result
+        }
+
+        fun toMaskedByteArray(): ByteArray {
+            val raw = this.toByteArray()
+            for (i in 0 until 6) raw[i] = 0.toByte()
+            for (i in 10 until 16) raw[i] = 0.toByte()
+            return raw
+        }
+
+        companion object {
+            fun fromByteArray(bytes: ByteArray): MifareTrailerBlock {
+                require(bytes.size == 16) { "Trailer block bytes must be 16 bytes" }
+                return MifareTrailerBlock(
+                    keyA = bytes.copyOfRange(0, 6),
+                    accessBits = bytes.copyOfRange(6, 9),
+                    userData = bytes[9],
+                    keyB = bytes.copyOfRange(10, 16)
+                )
+            }
+        }
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as MifareTrailerBlock
+
+            if (!keyA.contentEquals(other.keyA)) return false
+            if (!accessBits.contentEquals(other.accessBits)) return false
+            if (userData != other.userData) return false
+            if (!keyB.contentEquals(other.keyB)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = keyA.contentHashCode()
+            result = 31 * result + accessBits.contentHashCode()
+            result = 31 * result + userData
+            result = 31 * result + keyB.contentHashCode()
+            return result
+        }
+    }
     @JvmInline
     value class MifareBlock(val data: ByteArray) {
         init {
@@ -18,7 +79,6 @@ data class MifareClassicSector(
         val dataBlkSize = dataBlocks.size
         require(dataBlkSize == 3 || dataBlkSize == 15) { "Invalid data blocks size: $dataBlkSize" }
         require(dataBlocks.all { it.data.size == MIFARE_CLASSICAL_BLOCK_SIZE }) { "Each data block must be 16 bytes" }
-        require(trailerBlock.size == 16) { "Trailer block must be 16 bytes" }
     }
 
     override fun equals(other: Any?): Boolean {
@@ -28,14 +88,14 @@ data class MifareClassicSector(
         other as MifareClassicSector
 
         if (!dataBlocks.contentDeepEquals(other.dataBlocks)) return false
-        if (!trailerBlock.contentEquals(other.trailerBlock)) return false
+        if (trailerBlock != other.trailerBlock) return false
 
         return true
     }
 
     override fun hashCode(): Int {
         var result = dataBlocks.contentDeepHashCode()
-        result = 31 * result + trailerBlock.contentHashCode()
+        result = 31 * result + trailerBlock.hashCode()
         return result
     }
 }

--- a/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/BaseFakeTag.kt
@@ -22,13 +22,17 @@ abstract class BaseFakeTag {
         var lastConnectedTechnology = TagTechnology.Unknown
         var lastHandle: Int = -1
 
+        fun create(tech: String): BaseFakeTag? {
+            return TAG_TYPE_MAPPING[tech]?.getDeclaredConstructor()?.newInstance()
+        }
+
         fun createTagEndpoint(
             nfcClassloader: ClassLoader,
             tagEndpointInterface: Class<*>,
             uid: ByteArray,
             techList: IntArray,
             techExtras: Array<Bundle>,
-            transceive: (cmd: ByteArray) -> Pair<Boolean, ByteArray>,
+            transceive: (cmd: ByteArray) -> ByteArray?,
             ndef: NdefMessage? = null
         ): Any {
             lastHandle = random.nextInt(Int.MAX_VALUE) + 1
@@ -48,27 +52,16 @@ abstract class BaseFakeTag {
                         val data = args?.firstOrNull { it is ByteArray } as? ByteArray
                         val raw = args?.firstOrNull { it is Boolean } as? Boolean
                         val returnCode = args?.firstOrNull { it is IntArray } as? IntArray
-                        raw?.let {
-                            if (!it) {
-                                data?.let {
-                                    val result = transceive(data)
-                                    if (result.first) {
-                                        returnCode?.set(0, 0)
-                                    } else {
-                                        returnCode?.set(0, -4)
-                                    }
-                                    result.second
-                                } ?: run {
-                                    returnCode?.set(0, 0)
-                                    byteArrayOf()
-                                }
+                        if (data != null && raw != null && returnCode != null) {
+                            returnCode[0] = 0
+                            if (raw) {
+                                null
                             } else {
-                                returnCode?.set(0, 0)
-                                byteArrayOf()
+                                transceive(data)
                             }
-                        } ?: run {
+                        } else {
                             returnCode?.set(0, 0)
-                            byteArrayOf()
+                            null
                         }
                     }
                     "getConnectedTechnology" -> lastConnectedTechnology.flag

--- a/app/src/main/java/mba/vm/onhit/core/tag/MifareClassic.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/MifareClassic.kt
@@ -1,18 +1,34 @@
 package mba.vm.onhit.core.tag
 
+import android.nfc.NdefMessage
 import android.os.Bundle
 import mba.vm.onhit.core.TagTechnology
-import mba.vm.onhit.core.mfc.MifareClassicSector
 import mba.vm.onhit.core.mfc.MifareClassicParser
+import mba.vm.onhit.core.mfc.MifareClassicParser.checkNdef
+import mba.vm.onhit.core.mfc.MifareClassicParser.maxNdefMessageSize
+import mba.vm.onhit.core.mfc.MifareClassicSector
 
-// WIP
 class MifareClassic : BaseFakeTag() {
     var uid: ByteArray = byteArrayOf()
     var sectors: Array<MifareClassicSector> = arrayOf()
     var atqa: ByteArray = byteArrayOf(0x00, 0x04)
     var sak: Short = 0x08
+    var ndef: NdefMessage? = null
+    var techs: MutableList<TagTechnology> = mutableListOf(TagTechnology.NFC_A, TagTechnology.MIFARE_CLASSIC)
+    var extras: MutableList<Bundle> = mutableListOf(
+        Bundle().apply {
+            putShort("sak", sak)
+            putByteArray("atqa", atqa)
+        },
+        Bundle()
+    )
     var currentUnlockSectorIndex: Int = -1
 
+    /**
+     * Initializes the fake tag using raw binary dump bytes from a Proxmark3 (pm3) Mifare Classic export.
+     *
+     * NOTE: The configured [uid] might differ from the first 4 bytes of Block 0 (the manufacturer block).
+     */
     override fun init(uid: ByteArray, bytes: ByteArray): BaseFakeTag {
         this.uid = uid
         sectors = MifareClassicParser.parse(bytes)
@@ -20,6 +36,18 @@ class MifareClassic : BaseFakeTag() {
             val cardInfo = MifareClassicParser.getTagInfo(sectors[0])
             atqa = cardInfo.first ?: byteArrayOf(0x00, 0x04)
             sak = cardInfo.second?.toShort() ?: 0x08
+        }
+        ndef = checkNdef(sectors)
+        if (ndef != null) {
+            techs.add(TagTechnology.NDEF)
+            extras.add(
+                Bundle().apply {
+                    putParcelable("ndefmsg", ndef)
+                    putInt("ndefmaxlength", sectors.maxNdefMessageSize)
+                    putInt("ndefcardstate", 4)
+                    putInt("ndeftype", 1)
+                }
+            )
         }
         return this
     }
@@ -30,15 +58,10 @@ class MifareClassic : BaseFakeTag() {
             val size = sector.dataBlocks.size + 1
             if (targetBlock < currentTotal + size) {
                 val rel = targetBlock - currentTotal
-                if (rel < sector.dataBlocks.size) {
-                    return sector.dataBlocks[rel].data
+                return if (rel < sector.dataBlocks.size) {
+                    sector.dataBlocks[rel].data
                 } else {
-                    val rawTrailer = sector.trailerBlock
-                    if (rawTrailer.size < 16) return rawTrailer
-                    val maskedTrailer = ByteArray(16)
-                    System.arraycopy(rawTrailer, 6, maskedTrailer, 6, 4)
-                    System.arraycopy(rawTrailer, 10, maskedTrailer, 10, 6)
-                    return maskedTrailer
+                    sector.trailerBlock.toMaskedByteArray()
                 }
             }
             currentTotal += size
@@ -46,69 +69,51 @@ class MifareClassic : BaseFakeTag() {
         return null
     }
 
-    fun authentication(cmd: ByteArray): Pair<Boolean, ByteArray> {
+    fun authentication(cmd: ByteArray): ByteArray? {
         currentUnlockSectorIndex = -1
-        fun auth(sectorIndex: Int, isKeyB: Boolean, key: ByteArray): Pair<Boolean, ByteArray> {
-            val sector = sectors.getOrNull(sectorIndex) ?: return Pair(false, byteArrayOf())
-            val targetKey = if (isKeyB) {
-                sector.trailerBlock.sliceArray(10..15)
-            } else {
-                sector.trailerBlock.sliceArray(0..5)
-            }
-            return if (key.contentEquals(targetKey)) {
-                currentUnlockSectorIndex = sectorIndex
-                Pair(true, byteArrayOf(0x00))
-            } else {
-                Pair(false, byteArrayOf())
-            }
-        }
-        if (cmd.size < 12) return Pair(false, byteArrayOf())
+        if (cmd.size < 12) return null
         val targetBlock = cmd[1].toInt() and 0xFF
         val sectorIndex = MifareClassicParser.blockToSector(targetBlock)
         val providedKey = cmd.sliceArray(6..11)
-        return auth(sectorIndex, (cmd[0].toInt() and 0xFF) == 0x61, providedKey)
+        val isKeyB = (cmd[0].toInt() and 0xFF) == 0x61
+        val sector = sectors.getOrNull(sectorIndex) ?: return null
+        val targetKey = if (isKeyB) sector.trailerBlock.keyB else sector.trailerBlock.keyA
+        return if (providedKey.contentEquals(targetKey)) {
+            currentUnlockSectorIndex = sectorIndex
+            byteArrayOf(0x00)
+        } else {
+            null
+        }
     }
 
-    fun transceive(req: ByteArray): Pair<Boolean, ByteArray> {
-        if (req.isEmpty()) return Pair(false, byteArrayOf())
+    fun transceive(req: ByteArray): ByteArray? {
+        // I don't think we need write functionality; this is just a read-only PoC. I guess.
+        if (req.isEmpty()) return null
         val firstByte = req[0].toInt() and 0xFF
+
         when (firstByte) {
             0x60, 0x61 -> return authentication(req)
             0x30 -> {
-                if (req.size < 2) return Pair(false, byteArrayOf())
+                if (req.size < 2) return null
                 val targetBlock = req[1].toInt() and 0xFF
-                if (currentUnlockSectorIndex != MifareClassicParser.blockToSector(targetBlock)) {
-                    return Pair(false, byteArrayOf())
-                }
+                if (currentUnlockSectorIndex != MifareClassicParser.blockToSector(targetBlock)) return null
                 val blockData = getBlockData(targetBlock)
-                return if (blockData != null) {
-                    Pair(true, blockData)
-                } else {
-                    Pair(false, byteArrayOf())
-                }
+                return blockData
             }
         }
-        return Pair(true, byteArrayOf())
+        return null
     }
 
     override fun makeEndpoint(
         nfcClassloader: ClassLoader,
         tagEndpointInterface: Class<*>
     ): Any = createTagEndpoint(
-            nfcClassloader,
-            tagEndpointInterface,
-            uid,
-            TagTechnology.arrayOfTagTechnology(
-                TagTechnology.NFC_A,
-                TagTechnology.MIFARE_CLASSIC
-            ),
-            arrayOf(
-                Bundle().apply {
-                    putShort("sak", sak)
-                    putByteArray("atqa", atqa)
-                },
-                Bundle()
-            ),
-            ::transceive
-        )
+        nfcClassloader,
+        tagEndpointInterface,
+        uid,
+        TagTechnology.arrayOfTagTechnology(*techs.toTypedArray()),
+        extras.toTypedArray(),
+        ::transceive,
+        ndef = ndef
+    )
 }

--- a/app/src/main/java/mba/vm/onhit/core/tag/Ndef.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/Ndef.kt
@@ -28,7 +28,7 @@ class Ndef : BaseFakeTag() {
             putInt("ndefcardstate", 1)
             putInt("ndeftype", 4)
         }),
-        { Pair(true, byteArrayOf()) },
+        { null },
         ndefMessage
     )
 }

--- a/app/src/main/java/mba/vm/onhit/hook/boardcast/NfcServiceHookBroadcastReceiver.kt
+++ b/app/src/main/java/mba/vm/onhit/hook/boardcast/NfcServiceHookBroadcastReceiver.kt
@@ -4,7 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import mba.vm.onhit.Constant
-import mba.vm.onhit.core.tag.BaseFakeTag.Companion.TAG_TYPE_MAPPING
+import mba.vm.onhit.core.tag.BaseFakeTag
 import mba.vm.onhit.hook.NfcDispatchManagerHook.log
 import mba.vm.onhit.hook.NfcServiceHook.dispatchFakeTag
 
@@ -18,8 +18,8 @@ class NfcServiceHookBroadcastReceiver : BroadcastReceiver() {
                 val tagType = intent.getStringExtra("tagType") ?: "ndef"
                 try {
                     if (uid != null && data != null) {
-                        TAG_TYPE_MAPPING[tagType]?.let { clazz ->
-                            val tag = clazz.getDeclaredConstructor().newInstance().init(uid, data)
+                        BaseFakeTag.create(tagType)?.let { tag ->
+                            tag.init(uid, data)
                             dispatchFakeTag(tag)
                         }
                     }

--- a/app/src/main/java/mba/vm/onhit/utils/HexUtils.kt
+++ b/app/src/main/java/mba/vm/onhit/utils/HexUtils.kt
@@ -8,6 +8,10 @@ object HexUtils {
             s.substring(it * 2, it * 2 + 2).toInt(16).toByte()
         }
     }
+
+    fun encodeHex(bytes: ByteArray?): String {
+        return bytes?.joinToString("") { "%02X".format(it) } ?: ""
+    }
     
     fun filterHex(s: String): String {
         return s.filter { it.isDigit() || it.uppercaseChar() in 'A'..'F' }


### PR DESCRIPTION
- Introduce `MifareTrailerBlock` data class to handle keyA, accessBits, and keyB mapping.
- Add `checkNdef` parser to decode NDEF messages from raw Mifare Classic sectors.
- Refactor `transceive` and `authentication` in `MifareClassic` to return nullable `ByteArray?` instead of `Pair<Boolean, ByteArray>`.
- Dynamically append `TagTechnology.NDEF` and inject `ndefmsg` extras if NDEF content is present.
- Simplify fake tag creation with a factory method `BaseFakeTag.create()`.