### PR TITLE
refactor(nfc): optimize MifareClassicParser and refactor data models to List

### DIFF
--- a/app/src/main/java/mba/vm/onhit/Constant.kt
+++ b/app/src/main/java/mba/vm/onhit/Constant.kt
@@ -21,6 +21,7 @@ class Constant {
 
         const val REQUEST_SELECT_BACKGROUND = 1002
         const val REQUEST_CROP_BACKGROUND = 1003
+        const val MIFARE_CLASSICAL_BLOCK_SIZE = 16
         val PACKAGE_MANAGER_SYSTEM_NFC_FEATURES = setOf(PackageManager.FEATURE_NFC, PACKAGE_MANAGER_FEATURE_NFC_ANY)
     }
 }

--- a/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicParser.kt
+++ b/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicParser.kt
@@ -2,15 +2,20 @@ package mba.vm.onhit.core.mfc
 
 import android.nfc.NdefMessage
 import android.util.Log
+import mba.vm.onhit.Constant.Companion.MIFARE_CLASSICAL_BLOCK_SIZE
 import mba.vm.onhit.utils.HexUtils.encodeHex
 import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
 
 object MifareClassicParser {
-    const val MIFARE_CLASSICAL_BLOCK_SIZE = 16
+    private const val TAG_NULL = 0x00
+    private const val TAG_NDEF = 0x03
+    private const val TAG_TERMINATOR = 0xFE
+
     val KEY_MAD_NFC_FORUM = byteArrayOf(0xA0.toByte(), 0xA1.toByte(), 0xA2.toByte(), 0xA3.toByte(), 0xA4.toByte(), 0xA5.toByte())
     val KEY_NDEF_APPLICATION = byteArrayOf(0xD3.toByte(), 0xF7.toByte(), 0xD3.toByte(), 0xF7.toByte(), 0xD3.toByte(), 0xF7.toByte())
 
-    fun checkNdef(sectors: Array<MifareClassicSector>): NdefMessage? {
+    fun checkNdef(sectors: List<MifareClassicSector>): NdefMessage? {
         if (sectors.isEmpty()) return null
         val allDataBytes = ByteArrayOutputStream()
         for ((sectorIndex, sector) in sectors.withIndex()) {
@@ -28,16 +33,19 @@ object MifareClassicParser {
         return runCatching {
             var index = 0
             var ndefBytes: ByteArray? = null
+
             while (index < rawBytes.size) {
                 val tag = rawBytes[index].toInt() and 0xFF
                 when (tag) {
-                    0x00 -> index++
-                    0xFE -> break
-                    0x03 -> {
+                    TAG_NULL -> index++
+                    TAG_TERMINATOR -> break
+                    TAG_NDEF -> {
                         index++
+                        if (index >= rawBytes.size) break
                         var length = rawBytes[index].toInt() and 0xFF
                         index++
                         if (length == 0xFF) {
+                            if (index + 1 >= rawBytes.size) break
                             val lenH = rawBytes[index].toInt() and 0xFF
                             val lenL = rawBytes[index + 1].toInt() and 0xFF
                             length = (lenH shl 8) or lenL
@@ -48,75 +56,66 @@ object MifareClassicParser {
                     }
                     else -> {
                         index++
+                        if (index >= rawBytes.size) break
                         val length = rawBytes[index].toInt() and 0xFF
                         index += 1 + length
                     }
                 }
             }
             ndefBytes?.let {
-                Log.i(this::class.simpleName, "NDEF Data: ${encodeHex(it)}")
+                Log.i("MifareClassicParser", "NDEF Data: ${encodeHex(it)}")
                 NdefMessage(it)
             }
         }.onFailure { e ->
-            Log.e(this::class.simpleName, "Parsing NDEF failed", e)
+            Log.e("MifareClassicParser", "Parsing NDEF failed", e)
         }.getOrNull()
     }
-    fun parse(fileBytes: ByteArray): Array<MifareClassicSector> {
-        val sectors = mutableListOf<MifareClassicSector>()
-        var byteOffset = 0
 
-        while (byteOffset < fileBytes.size) {
+    fun parse(fileBytes: ByteArray): List<MifareClassicSector> {
+        val sectors = mutableListOf<MifareClassicSector>()
+        val buffer = ByteBuffer.wrap(fileBytes)
+
+        while (buffer.hasRemaining()) {
             val sectorIndex = sectors.size
             val blocksInThisSector = if (sectorIndex < 32) 4 else 16
-            val sectorSizeInBytes = blocksInThisSector * 16
-            if (byteOffset + sectorSizeInBytes > fileBytes.size) {
-                break
+            val sectorSizeInBytes = blocksInThisSector * MIFARE_CLASSICAL_BLOCK_SIZE
+
+            if (buffer.remaining() < sectorSizeInBytes) break
+            val dataBlocks = List(blocksInThisSector - 1) {
+                val blockBytes = ByteArray(MIFARE_CLASSICAL_BLOCK_SIZE)
+                buffer.get(blockBytes)
+                MifareClassicSector.MifareBlock(blockBytes)
             }
-            val sectorData = fileBytes.sliceArray(
-                byteOffset until (byteOffset + sectorSizeInBytes)
-            )
-            val dataBlocks = Array(blocksInThisSector - 1) { i ->
-                MifareClassicSector.MifareBlock(
-                    sectorData.sliceArray(
-                        i * MIFARE_CLASSICAL_BLOCK_SIZE until
-                                (i + 1) * MIFARE_CLASSICAL_BLOCK_SIZE
-                    )
-                )
-            }
-            val trailerBlock = sectorData.sliceArray(
-                (blocksInThisSector - 1) * MIFARE_CLASSICAL_BLOCK_SIZE until sectorSizeInBytes
-            )
-            sectors.add(
-                MifareClassicSector(
-                    dataBlocks,
-                    MifareClassicSector.MifareTrailerBlock.fromByteArray(trailerBlock)
-                )
-            )
-            byteOffset += sectorSizeInBytes
+            val trailerBytes = ByteArray(MIFARE_CLASSICAL_BLOCK_SIZE)
+            buffer.get(trailerBytes)
+            val trailerBlock = MifareClassicSector.MifareTrailerBlock.fromByteArray(trailerBytes)
+            sectors.add(MifareClassicSector(dataBlocks, trailerBlock))
         }
-        return sectors.toTypedArray()
+        return sectors
     }
 
     fun getTagInfo(sector: MifareClassicSector): Pair<ByteArray?, Byte?> {
-        if (sector.dataBlocks.isEmpty()) return null to null
-        val block0 = sector.dataBlocks[0].data
+        val block0 = sector.dataBlocks.getOrNull(0)?.data ?: return null to null
         if (block0.size < 8) return null to null
+
         val sak = block0[5]
         val atqa = byteArrayOf(block0[6], block0[7])
         return atqa to sak
     }
 
     fun blockToSector(blockIndex: Int): Int {
-        if (blockIndex !in 0..<256) return -1
-        return if (blockIndex < 32 * 4) blockIndex / 4
-        else 32 + (blockIndex - 32 * 4) / 16
+        if (blockIndex !in 0..255) return -1
+        return if (blockIndex < 128) {
+            blockIndex ushr 2
+        } else {
+            32 + ((blockIndex - 128) ushr 4)
+        }
     }
 
-    val Array<MifareClassicSector>.maxNdefMessageSize: Int
+    val List<MifareClassicSector>.maxNdefMessageSize: Int
         get() {
             if (this.size < 2) return 0
-            val ndefSectors = this.drop(1)
-            val totalNdefPhysicalBytes = ndefSectors.sumOf { sector ->
+            val totalNdefPhysicalBytes = this.subList(1, this.size).sumOf { sector ->
                 sector.dataBlocks.size * MIFARE_CLASSICAL_BLOCK_SIZE
             }
             if (totalNdefPhysicalBytes == 0) return 0

--- a/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicSector.kt
+++ b/app/src/main/java/mba/vm/onhit/core/mfc/MifareClassicSector.kt
@@ -1,12 +1,12 @@
 package mba.vm.onhit.core.mfc
 
-import mba.vm.onhit.core.mfc.MifareClassicParser.MIFARE_CLASSICAL_BLOCK_SIZE
+import mba.vm.onhit.Constant.Companion.MIFARE_CLASSICAL_BLOCK_SIZE
+
 
 data class MifareClassicSector(
-    var dataBlocks: Array<MifareBlock>,
-    var trailerBlock: MifareTrailerBlock
+    val dataBlocks: List<MifareBlock>,
+    val trailerBlock: MifareTrailerBlock
 ) {
-
     data class MifareTrailerBlock(
         val keyA: ByteArray = ByteArray(6) { 0xFF.toByte() },
         val accessBits: ByteArray = byteArrayOf(0xFF.toByte(), 0x07.toByte(), 0x80.toByte()),
@@ -19,6 +19,7 @@ data class MifareClassicSector(
             require(keyB.size == 6) { "Key B must be 6 bytes" }
         }
 
+        @Suppress("unused")
         fun toByteArray(): ByteArray {
             val result = ByteArray(16)
             System.arraycopy(keyA, 0, result, 0, 6)
@@ -29,10 +30,10 @@ data class MifareClassicSector(
         }
 
         fun toMaskedByteArray(): ByteArray {
-            val raw = this.toByteArray()
-            for (i in 0 until 6) raw[i] = 0.toByte()
-            for (i in 10 until 16) raw[i] = 0.toByte()
-            return raw
+            val result = ByteArray(16)
+            System.arraycopy(accessBits, 0, result, 6, 3)
+            result[9] = userData
+            return result
         }
 
         companion object {
@@ -49,15 +50,11 @@ data class MifareClassicSector(
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false
-
             other as MifareTrailerBlock
-
-            if (!keyA.contentEquals(other.keyA)) return false
-            if (!accessBits.contentEquals(other.accessBits)) return false
-            if (userData != other.userData) return false
-            if (!keyB.contentEquals(other.keyB)) return false
-
-            return true
+            return userData == other.userData &&
+                    keyA.contentEquals(other.keyA) &&
+                    accessBits.contentEquals(other.accessBits) &&
+                    keyB.contentEquals(other.keyB)
         }
 
         override fun hashCode(): Int {
@@ -68,6 +65,7 @@ data class MifareClassicSector(
             return result
         }
     }
+
     @JvmInline
     value class MifareBlock(val data: ByteArray) {
         init {
@@ -78,24 +76,26 @@ data class MifareClassicSector(
     init {
         val dataBlkSize = dataBlocks.size
         require(dataBlkSize == 3 || dataBlkSize == 15) { "Invalid data blocks size: $dataBlkSize" }
-        require(dataBlocks.all { it.data.size == MIFARE_CLASSICAL_BLOCK_SIZE }) { "Each data block must be 16 bytes" }
     }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
-
         other as MifareClassicSector
 
-        if (!dataBlocks.contentDeepEquals(other.dataBlocks)) return false
         if (trailerBlock != other.trailerBlock) return false
-
+        if (dataBlocks.size != other.dataBlocks.size) return false
+        for (i in dataBlocks.indices) {
+            if (!dataBlocks[i].data.contentEquals(other.dataBlocks[i].data)) return false
+        }
         return true
     }
 
     override fun hashCode(): Int {
-        var result = dataBlocks.contentDeepHashCode()
-        result = 31 * result + trailerBlock.hashCode()
+        var result = trailerBlock.hashCode()
+        for (block in dataBlocks) {
+            result = 31 * result + block.data.contentHashCode()
+        }
         return result
     }
 }

--- a/app/src/main/java/mba/vm/onhit/core/tag/MifareClassic.kt
+++ b/app/src/main/java/mba/vm/onhit/core/tag/MifareClassic.kt
@@ -10,7 +10,7 @@ import mba.vm.onhit.core.mfc.MifareClassicSector
 
 class MifareClassic : BaseFakeTag() {
     var uid: ByteArray = byteArrayOf()
-    var sectors: Array<MifareClassicSector> = arrayOf()
+    var sectors: List<MifareClassicSector> = listOf()
     var atqa: ByteArray = byteArrayOf(0x00, 0x04)
     var sak: Short = 0x08
     var ndef: NdefMessage? = null
@@ -38,11 +38,11 @@ class MifareClassic : BaseFakeTag() {
             sak = cardInfo.second?.toShort() ?: 0x08
         }
         ndef = checkNdef(sectors)
-        if (ndef != null) {
+        ndef?.let {
             techs.add(TagTechnology.NDEF)
             extras.add(
                 Bundle().apply {
-                    putParcelable("ndefmsg", ndef)
+                    putParcelable("ndefmsg", it)
                     putInt("ndefmaxlength", sectors.maxNdefMessageSize)
                     putInt("ndefcardstate", 4)
                     putInt("ndeftype", 1)

--- a/app/src/main/java/mba/vm/onhit/ui/FileAdapter.kt
+++ b/app/src/main/java/mba/vm/onhit/ui/FileAdapter.kt
@@ -60,7 +60,6 @@ class FileAdapter(
             override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
                 val oldItem = fileList[oldItemPosition]
                 val newItem = newList[newItemPosition]
-                // 假设 DocumentFile 的 URI 或路径可以唯一标识一个文件
                 return oldItem.name == newItem.name && oldItem.isDirectory == newItem.isDirectory
             }
 


### PR DESCRIPTION
- Move `MIFARE_CLASSICAL_BLOCK_SIZE` to global `Constant`.
- Change `sectors` from `Array` to `List` in MifareClassic tags and parser.
- Use `ByteBuffer` in `MifareClassicParser.parse` to avoid manual offset tracking.
- Add boundary checks inside `checkNdef` to prevent potential out-of-bounds exceptions.
- Simplify `toMaskedByteArray` and improve performance of `equals` / `hashCode` in `MifareClassicSector`.
- Clean up unused comments and replace hardcoded logging tags.