### PR TITLE
fix(ui): handle null response values in tag trace clipboard export

### DIFF
--- a/app/src/main/java/mba/vm/onhit/ui/dialog/TagTraceDialog.kt
+++ b/app/src/main/java/mba/vm/onhit/ui/dialog/TagTraceDialog.kt
@@ -105,7 +105,7 @@ class TagTraceDialog(
         private fun copyToClipboard(context: Context, item: TagTrace.TransceiveData) {
             val json = JSONObject().apply {
                 put("cmd", HexUtils.toHexString(item.cmd))
-                put("resp", item.resp?.let { HexUtils.toHexString(it) })
+                put("resp", item.resp?.let { HexUtils.toHexString(it) } ?: JSONObject.NULL)
                 put("raw", item.raw)
                 put("returnCodes", JSONArray(item.returnCodes))
             }.toString()


### PR DESCRIPTION
- **Tag Trace**: Update `copyToClipboard` in `TagTraceDialog` to explicitly use `JSONObject.NULL` for missing response data. This ensures the `"resp"` key is consistently present in the exported JSON string even when no response is recorded.