### PR TITLE
feat(shortcut): add desktop shortcut support for tag emulation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.ShortcutHandleActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
         <activity-alias
             android:name=".ImportHandler"
             android:targetActivity=".ui.MainActivity"

--- a/app/src/main/java/mba/vm/onhit/Constant.kt
+++ b/app/src/main/java/mba/vm/onhit/Constant.kt
@@ -30,6 +30,8 @@ class Constant {
         const val REQUEST_SELECT_NDEF_FILE = 1004
         const val REQUEST_SAVE_FILE = 1005
         const val REQUEST_EDIT_NDEF = 1006
+        const val REQUEST_SELECT_SHORTCUT_ICON = 1007
+        const val REQUEST_CROP_SHORTCUT_ICON = 1008
 
         const val MIFARE_CLASSICAL_BLOCK_SIZE = 16
         val PACKAGE_MANAGER_SYSTEM_NFC_FEATURES = setOf(PackageManager.FEATURE_NFC, PACKAGE_MANAGER_FEATURE_NFC_ANY)

--- a/app/src/main/java/mba/vm/onhit/ui/MainActivity.kt
+++ b/app/src/main/java/mba/vm/onhit/ui/MainActivity.kt
@@ -1,8 +1,10 @@
 package mba.vm.onhit.ui
 
 import android.app.Activity
+import android.app.Dialog
 import android.content.Intent
 import android.content.IntentFilter
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.text.Editable
@@ -43,6 +45,7 @@ import mba.vm.onhit.utils.FileUtils
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import androidx.core.graphics.scale
 
 class MainActivity : Activity() {
     private lateinit var binding: ActivityMainBinding
@@ -59,6 +62,8 @@ class MainActivity : Activity() {
     private lateinit var importController: ImportController
 
     private var activeNdefDialog: NdefEditorDialog? = null
+    private var activeShortcutDialog: Dialog? = null
+    private var shortcutIconUri: Uri? = null
     private var fileToEdit: DocumentFile? = null
     private val responseBroadcastReceiver = ResponseBroadcastReceiver()
     private var recorderState: String? = null
@@ -341,6 +346,9 @@ class MainActivity : Activity() {
         if (fileData.type == FileType.NDEF && nfcHandler.isEnabled() && !importController.isImportMode()) popup.menu.add(0, 3, 2, R.string.menu_write_to_tag)
         if (fileData.type == FileType.NDEF) popup.menu.add(0, 4, 3, R.string.menu_edit_ndef)
         if (fileData.type == FileType.TagTrace) popup.menu.add(0, 5, 4, R.string.menu_view_trace)
+        if (fileData.type == FileType.NDEF || fileData.type == FileType.MifareClassic || fileData.type == FileType.TagTrace) {
+            popup.menu.add(0, 6, 5, R.string.menu_create_shortcut)
+        }
 
         popup.setOnMenuItemClickListener { item ->
             when (item.itemId) {
@@ -385,10 +393,115 @@ class MainActivity : Activity() {
                         }
                     }
                 }
+                6 -> {
+                    shortcutIconUri = null
+                    val defaultName = fileData.name
+                    activeShortcutDialog = DialogHelper.showShortcutBottomSheet(
+                        this,
+                        defaultName,
+                        onChangeIcon = {
+                            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                                addCategory(Intent.CATEGORY_OPENABLE)
+                                type = "image/*"
+                            }
+                            startActivityForResult(intent, Constant.REQUEST_SELECT_SHORTCUT_ICON)
+                        },
+                        onConfirm = { name ->
+                            requestCreateShortcut(fileData, name)
+                        }
+                    )
+                    activeShortcutDialog?.setOnDismissListener { activeShortcutDialog = null }
+                }
             }
             true
         }
         popup.show()
+    }
+
+    private fun startCropShortcutIcon(sourceUri: Uri) {
+        val outputFile = java.io.File(filesDir, "shortcut_icon_cropped.png")
+        if (!outputFile.exists()) {
+            outputFile.createNewFile()
+        }
+        val outputUri = androidx.core.content.FileProvider.getUriForFile(this, "$packageName.fileprovider", outputFile)
+        shortcutIconUri = outputUri
+
+        val cropIntent = Intent("com.android.camera.action.CROP").apply {
+            setDataAndType(sourceUri, "image/*")
+            putExtra("crop", "true")
+            putExtra("aspectX", 1)
+            putExtra("aspectY", 1)
+            putExtra("scale", true)
+            putExtra("return-data", false)
+            putExtra(android.provider.MediaStore.EXTRA_OUTPUT, outputUri)
+            putExtra("outputFormat", android.graphics.Bitmap.CompressFormat.PNG.toString())
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            clipData = android.content.ClipData.newRawUri("cropped_icon", outputUri)
+        }
+
+        val resInfoList = packageManager.queryIntentActivities(cropIntent, android.content.pm.PackageManager.MATCH_DEFAULT_ONLY)
+        for (resolveInfo in resInfoList) {
+            val pName = resolveInfo.activityInfo.packageName
+            grantUriPermission(pName, sourceUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            grantUriPermission(pName, outputUri, Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+        }
+
+        try {
+            startActivityForResult(cropIntent, Constant.REQUEST_CROP_SHORTCUT_ICON)
+        } catch (_: Exception) {
+            Toast.makeText(this, R.string.unknown_error, Toast.LENGTH_SHORT).show()
+            activeShortcutDialog?.findViewById<android.widget.ImageView>(R.id.iv_shortcut_icon)?.setImageURI(sourceUri)
+            shortcutIconUri = sourceUri
+        }
+    }
+
+    private fun requestCreateShortcut(fileData: FileData, name: String) {
+        val fileUri = fileData.documentFile?.uri ?: return
+        val tagType = when(fileData.type) {
+            FileType.NDEF -> mba.vm.onhit.hook.core.tag.TagType.NDEF.value
+            FileType.MifareClassic -> mba.vm.onhit.hook.core.tag.TagType.MFC.value
+            FileType.TagTrace -> mba.vm.onhit.hook.core.tag.TagType.TRACE.value
+            else -> return
+        }
+
+        val intent = Intent(this, ShortcutHandleActivity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            putExtra("file_uri", fileUri.toString())
+            putExtra("tag_type", tagType.toInt())
+        }
+
+        var iconCompat: androidx.core.graphics.drawable.IconCompat? = null
+        if (shortcutIconUri != null) {
+            try {
+                contentResolver.openInputStream(shortcutIconUri!!)?.use { input ->
+                    val bitmap = android.graphics.BitmapFactory.decodeStream(input)
+                    if (bitmap != null) {
+                        val scaledBitmap = bitmap.scale(192, 192)
+                        iconCompat = androidx.core.graphics.drawable.IconCompat.createWithBitmap(scaledBitmap)
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+        if (iconCompat == null) {
+            iconCompat = androidx.core.graphics.drawable.IconCompat.createWithResource(this, R.mipmap.ic_launcher)
+        }
+
+        val shortcutId = "shortcut_${System.currentTimeMillis()}"
+        val shortcut = androidx.core.content.pm.ShortcutInfoCompat.Builder(this, shortcutId)
+            .setShortLabel(name)
+            .setIcon(iconCompat)
+            .setIntent(intent)
+            .build()
+
+        if (androidx.core.content.pm.ShortcutManagerCompat.isRequestPinShortcutSupported(this)) {
+            androidx.core.content.pm.ShortcutManagerCompat.requestPinShortcut(this, shortcut, null)
+            Toast.makeText(this, R.string.toast_shortcut_created, Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(this, R.string.toast_shortcut_unsupported, Toast.LENGTH_SHORT).show()
+        }
     }
 
     override fun onResume() {
@@ -424,6 +537,20 @@ class MainActivity : Activity() {
             Constant.REQUEST_SELECT_NDEF_FILE -> {
                 data?.data?.let { uri ->
                     activeNdefDialog?.handleFilePickResult(uri)
+                }
+            }
+            Constant.REQUEST_SELECT_SHORTCUT_ICON -> {
+                data?.data?.let { uri ->
+                    try {
+                        contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    } catch (_: Exception) {}
+                    startCropShortcutIcon(uri)
+                }
+            }
+            Constant.REQUEST_CROP_SHORTCUT_ICON -> {
+                shortcutIconUri?.let {
+                    activeShortcutDialog?.findViewById<android.widget.ImageView>(R.id.iv_shortcut_icon)?.setImageURI(null)
+                    activeShortcutDialog?.findViewById<android.widget.ImageView>(R.id.iv_shortcut_icon)?.setImageURI(it)
                 }
             }
         }

--- a/app/src/main/java/mba/vm/onhit/ui/ShortcutHandleActivity.kt
+++ b/app/src/main/java/mba/vm/onhit/ui/ShortcutHandleActivity.kt
@@ -1,0 +1,39 @@
+package mba.vm.onhit.ui
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.Toast
+import androidx.core.net.toUri
+import mba.vm.onhit.R
+import mba.vm.onhit.hook.core.tag.TagType
+
+class ShortcutHandleActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val uriStr = intent.getStringExtra("file_uri")
+        val tagTypeValue = intent.getIntExtra("tag_type", -1)
+
+        if (uriStr != null && tagTypeValue != -1) {
+            val uri = uriStr.toUri()
+            try {
+                val inputStream = contentResolver.openInputStream(uri)
+                if (inputStream == null) {
+                    Toast.makeText(this, R.string.toast_file_not_found, Toast.LENGTH_SHORT).show()
+                } else {
+                    inputStream.use { input ->
+                        val bytes = input.readBytes()
+                        val tagType = TagType.fromByte(tagTypeValue.toByte())
+                        mba.vm.onhit.ui.manager.TagEmulatorManager(this).sendEmulateBroadcast(bytes, tagType)
+                    }
+                }
+            } catch (_: java.io.FileNotFoundException) {
+                Toast.makeText(this, R.string.toast_file_not_found, Toast.LENGTH_SHORT).show()
+            } catch (e: Exception) {
+                Toast.makeText(this, getString(R.string.toast_send_broadcast_failed, e.message), Toast.LENGTH_SHORT).show()
+            }
+        } else {
+            Toast.makeText(this, R.string.toast_file_not_found, Toast.LENGTH_SHORT).show()
+        }
+        finishAndRemoveTask()
+    }
+}

--- a/app/src/main/java/mba/vm/onhit/ui/dialog/DialogHelper.kt
+++ b/app/src/main/java/mba/vm/onhit/ui/dialog/DialogHelper.kt
@@ -133,6 +133,36 @@ object DialogHelper {
         dialog.show()
     }
 
+    fun showShortcutBottomSheet(
+        activity: Activity,
+        defaultName: String,
+        onChangeIcon: () -> Unit,
+        onConfirm: (name: String) -> Unit
+    ): Dialog {
+        val dialog = createBottomDialog(activity, R.layout.bottom_dialog_shortcut)
+        val etName = dialog.findViewById<EditText>(R.id.et_shortcut_name)
+        val ivIcon = dialog.findViewById<android.widget.ImageView>(R.id.iv_shortcut_icon)
+        val btnOk = dialog.findViewById<Button>(R.id.btn_ok)
+        val btnCancel = dialog.findViewById<Button>(R.id.btn_cancel)
+
+        etName.setText(defaultName)
+
+        ivIcon.setOnClickListener {
+            onChangeIcon()
+        }
+
+        btnOk.setOnClickListener {
+            val name = etName.text.toString()
+            if (name.isNotEmpty()) {
+                onConfirm(name)
+                dialog.dismiss()
+            }
+        }
+        btnCancel.setOnClickListener { dialog.dismiss() }
+        dialog.show()
+        return dialog
+    }
+
     fun showNfcDialog(context: Context, title: String? = null, message: String? = null, onCancel: () -> Unit): Dialog {
         val dialog = createBottomDialog(context, R.layout.bottom_dialog_nfc)
         title?.let { dialog.findViewById<TextView>(R.id.tv_title)?.text = it }

--- a/app/src/main/java/mba/vm/onhit/ui/dialog/DialogHelper.kt
+++ b/app/src/main/java/mba/vm/onhit/ui/dialog/DialogHelper.kt
@@ -152,8 +152,8 @@ object DialogHelper {
         }
 
         btnOk.setOnClickListener {
-            val name = etName.text.toString()
-            if (name.isNotEmpty()) {
+            val name = etName.text.toString().trim()
+            if (name.isNotBlank()) {
                 onConfirm(name)
                 dialog.dismiss()
             }

--- a/app/src/main/java/mba/vm/onhit/ui/manager/MainIntentHandler.kt
+++ b/app/src/main/java/mba/vm/onhit/ui/manager/MainIntentHandler.kt
@@ -42,11 +42,18 @@ class MainIntentHandler(
 
     private fun handleBroadcastIntent(uri: Uri) {
         try {
-            activity.contentResolver.openInputStream(uri)?.use { input ->
-                val bytes = input.readBytes()
-                val detectedType = FileUtils.detectTagType(bytes)
-                tagEmulatorManager.sendEmulateBroadcast(bytes, detectedType)
+            val inputStream = activity.contentResolver.openInputStream(uri)
+            if (inputStream == null) {
+                Toast.makeText(activity, R.string.toast_file_not_found, Toast.LENGTH_SHORT).show()
+            } else {
+                inputStream.use { input ->
+                    val bytes = input.readBytes()
+                    val detectedType = FileUtils.detectTagType(bytes)
+                    tagEmulatorManager.sendEmulateBroadcast(bytes, detectedType)
+                }
             }
+        } catch (_: java.io.FileNotFoundException) {
+            Toast.makeText(activity, R.string.toast_file_not_found, Toast.LENGTH_SHORT).show()
         } catch (e: Exception) {
             Toast.makeText(activity, activity.getString(R.string.toast_send_broadcast_failed, e.message), Toast.LENGTH_SHORT).show()
         } finally {

--- a/app/src/main/res/layout/bottom_dialog_shortcut.xml
+++ b/app/src/main/res/layout/bottom_dialog_shortcut.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="@drawable/bg_bottom_sheet">
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/dialog_title_create_shortcut"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:textColor="?android:attr/textColorPrimary"
+        android:layout_marginBottom="16dp" />
+
+    <ImageView
+        android:id="@+id/iv_shortcut_icon"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:layout_gravity="center_horizontal"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:clickable="true"
+        android:contentDescription="@string/shortcut_icon"
+        android:focusable="true"
+        android:src="@mipmap/ic_launcher"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="8dp"
+        android:text="@string/hint_click_to_change_icon"
+        android:textSize="12sp"
+        android:textColor="?android:attr/textColorSecondary"
+        android:layout_marginBottom="16dp" />
+
+    <EditText
+        android:id="@+id/et_shortcut_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:autofillHints="no"
+        android:hint="@string/hint_shortcut_name"
+        android:inputType="text"
+        android:singleLine="true"
+        android:textColor="?android:attr/textColorPrimary" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:layout_marginTop="24dp">
+
+        <Button
+            android:id="@+id/btn_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@android:string/cancel"
+            style="?android:attr/borderlessButtonStyle" />
+
+        <Button
+            android:id="@+id/btn_ok"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@android:string/ok"
+            style="?android:attr/borderlessButtonStyle"
+            android:textColor="?android:attr/colorAccent" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -151,4 +151,12 @@
     <string name="trace_no_resp">无响应</string>
     <string name="trace_extra_info">原始数据: %1$b, 状态: %2$s</string>
     <string name="ssid">SSID</string>
+    <string name="menu_create_shortcut">创建桌面快捷方式</string>
+    <string name="dialog_title_create_shortcut">创建快捷方式</string>
+    <string name="hint_shortcut_name">快捷方式名称</string>
+    <string name="hint_click_to_change_icon">点击更换图标</string>
+    <string name="toast_file_not_found">文件不存在</string>
+    <string name="toast_shortcut_created">已请求创建快捷方式</string>
+    <string name="toast_shortcut_unsupported">当前桌面不支持创建快捷方式</string>
+    <string name="shortcut_icon">快捷方式图标</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,4 +154,12 @@
     <string name="trace_no_resp">No Response</string>
     <string name="trace_extra_info">raw: %1$b, status: %2$s</string>
     <string name="ssid">SSID</string>
+    <string name="menu_create_shortcut">Create Shortcut</string>
+    <string name="dialog_title_create_shortcut">Create Shortcut</string>
+    <string name="hint_shortcut_name">Shortcut Name</string>
+    <string name="hint_click_to_change_icon">Click to change icon</string>
+    <string name="toast_file_not_found">File does not exist</string>
+    <string name="toast_shortcut_created">Shortcut creation requested</string>
+    <string name="toast_shortcut_unsupported">Launcher does not support creating shortcuts</string>
+    <string name="shortcut_icon">Shortcut Icon</string>
 </resources>


### PR DESCRIPTION
- Add ShortcutHandleActivity to handle shortcut click and broadcast emulation
- Support creating pin shortcuts for NDEF, MifareClassic, and TagTrace files
- Support custom shortcut name and icon cropping
- Add localized string resources and improve file open error handling
- #100 